### PR TITLE
fix: UB on CxxrtlObject::value

### DIFF
--- a/cxxrtl/src/rtl.rs
+++ b/cxxrtl/src/rtl.rs
@@ -145,7 +145,7 @@ impl CxxrtlObject {
     fn values<const N: u32>(&self) -> (Value<N>, Option<Value<N>>) {
         let curr = unsafe { Value::new((*self.obj).curr) };
         let next = (unsafe { *self.obj }).next;
-        let next = (!next.is_null()).then_some(unsafe { Value::new(next) });
+        let next = (!next.is_null()).then(|| unsafe { Value::new(next) });
         (curr, next)
     }
 


### PR DESCRIPTION
tldr: the code inside bool::then_some is always executed, but the code in the closure from bool::then is only executed if is true.

This is UB, because the bool::then_some is a function that takes a bool and a generic value, because of that, the value inside of it is always evaluated, independent if the bool is true/false.

it's clear if the desugarize the syntax:

```rust
// first we get the true/false for the condition
let cond: bool = !next.is_null();
// then we evaluate the expression to pass the value as parameter
// UB here, the is executed always, independent of the cond being true/false
let value = unsafe { Value::new(next) };
// then we call the function `bool::then_some`.
bool::then_some(cond, value)
```

The solution is simply change it to bool::then, because the parameter it's a closure, it's lazy evaluated, and only executed if the condition is true.

As mentioned at https://github.com/rust-lang/rust/blob/5cb2e7dfc362662b0036faad3bab88d73027fd05/src/tools/clippy/clippy_lints/src/transmute/mod.rs#L468-L520

And presented at https://youtu.be/hBjQ3HqCfxs?si=nrIz6ZHnxEHO6Pik&t=53
